### PR TITLE
dunamai 1.17.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,34 +12,41 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<35]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   entry_points:
     - dunamai = dunamai.__main__:main
-  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - poetry-core >=1.0.0
-    - python >=3.5
+    - poetry-core 1.4.0
+    - python
+    - setuptools
+    - wheel
   run:
-    - importlib-metadata >=1.6.0
+    - importlib-metadata >=1.6.0  # [py<38]
     - packaging >=20.9
-    - python >=3.5
+    - python
 
 test:
   imports:
     - dunamai
+  requires:
+    - pip
   commands:
     - pip check
     - dunamai --help
-  requires:
-    - pip
 
 about:
   home: https://github.com/mtkennerly/dunamai
-  summary: Dynamic version generation
+  dev_url: https://github.com/mtkennerly/dunamai
+  doc_url: https://github.com/mtkennerly/dunamai
+  summary: Dynamic versioning library and CLI
+  description: |
+    Dunamai is a Python library and command line tool for producing dynamic, standards-compliant version strings, derived from tags in your version control system. This facilitates uniquely identifying nightly or per-commit builds in continuous integration and releasing new versions of your software simply by creating a tag.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   skip: True  # [py<35]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - dunamai = dunamai.__main__:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   host:
     - pip
-    - poetry-core 1.4.0
+    - poetry-core 1.5.1
     - python
     - setuptools
     - wheel


### PR DESCRIPTION
Changelog: https://github.com/mtkennerly/dunamai/blob/v1.17.0/CHANGELOG.md
License: https://github.com/mtkennerly/dunamai/blob/v1.17.0/LICENSE
Requirements: https://github.com/mtkennerly/dunamai/blob/v1.17.0/pyproject.toml


Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Skip `py<35`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` and `wheel` to `host`
  - Fix `python` in `host` and `run`
2. Add `poetry-core` pin **1.5.1** (note that 1.4.0 hasn't py311 support on ppc64le)
3. Add `dev_url` and `doc_url`
4. Update `summary`
5. Add `description`
6. Add `license_family`

Notes:
- `poetry-dynamic-versioning` requires it https://github.com/AnacondaRecipes/poetry-dynamic-versioning-feedstock/blob/a74b52647029b6a639c6989752f70002e185e0da/recipe/meta.yaml#L26 